### PR TITLE
Add optional configurable view options

### DIFF
--- a/MMM-Tankerkoenig.js
+++ b/MMM-Tankerkoenig.js
@@ -8,7 +8,7 @@ Module.register("MMM-Tankerkoenig", {
     },
     fuelTypes: ["e5", "e10", "diesel"],
     sortOptions: {
-      sortBy: 'stationOrder', // 'name' | 'price'| 'stationOrder'
+      sortBy: 'stationOrder', // 'name' | 'price' | 'stationOrder'
       direction: 'asc',       // 'asc' | 'desc'
       fuelType: 'e5'          // used only for sortBy === 'price'
     },

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@
             "474e5046-deaf-4f9b-9a32-9797b778f047": "Total Berlin", // another ID possible
         },
         fuelTypes: ["e5", "e10", "diesel"] // filter gas types
+        sortOptions: {
+            sortBy: 'name',        // 'name' | 'stationOrder' | 'price'
+            direction: 'asc',      // 'asc' | 'desc'
+            fuelType: 'e5'         // used only for sortBy === 'price'
+        },
+        options: {
+            priceRound: "down"     // 'up', 'down', 'none', 'commercial'
+        }
     }
 },
 ```
@@ -39,3 +47,18 @@ Looking to add more features in the future. Big thanks to Tankerkoenig for provi
 To help reduce network traffic, please enter the name of your desired station manually. 😊
 📢 Note
 Information accuracy isn’t guaranteed, and the API may change from free to paid access at any time.
+
+## Changelog
+
+### 1.1.0 - 2025-04-12
+- Add sorting possibilities with `sortOptions` property
+    - `sortBy` 'name', 'price' or 'stationOrder' for your own stationNames order
+    - `direction` 'asc' or 'desc'
+    - `fuelType` only for `sortBy === 'price'` and must be one of `fuelTypes`
+- Add `options` property with child `priceRound` for how the price will be displayed
+    - 'up' rounds up and results in 2 decimal digits
+    - 'down' rounds down and results in 2 decimal digits
+    - 'none' results in 3 decimal digits (rounds in a commercial way if necessary)
+    - 'commercial' rounds in a commercial way and results in 2 decimal digits
+- Add more (German) keywords for this module
+- Add contributor 'TobTra89'

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
             "24a381e3-0d72-416d-bfd8-b2f65f6e5802": "Esso Tankstelle", // ID with custom name
             "474e5046-deaf-4f9b-9a32-9797b778f047": "Total Berlin", // another ID possible
         },
-        fuelTypes: ["e5", "e10", "diesel"] // filter gas types
+        fuelTypes: ["e5", "e10", "diesel"], // filter gas types
         sortOptions: {
             sortBy: 'name',        // 'name' | 'stationOrder' | 'price'
             direction: 'asc',      // 'asc' | 'desc'

--- a/package.json
+++ b/package.json
@@ -1,15 +1,20 @@
 {
     "name": "mmm-tankerkoenig",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "MagicMirror² Module to display the local gas prices in Germany.",
     "main": "MMM-Tankerkoenig.js",
     "author": "wiesty",
+    "contributors": ["TobTra89"],
     "license": "CC BY-NC 4.0",
     "homepage": "https://github.com/wiesty/MMM-Tankerkoenig",
     "keywords": [
       "magic mirror",
       "gas",
-      "germany"
+      "refuel",
+      "germany",
+      "benzin",
+      "diesel",
+      "tanken"
     ],
     "repository": {
       "type": "git",


### PR DESCRIPTION
Add optional possibilities, configurable in the common config.js:
1. Sorting the defined stations
2. Define rounding behavior of the price

For details see the readme changelog entry for version 1.1.0